### PR TITLE
remove (Beta) from mainnet eth rpc connection

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/Preferences/Ethereum/Connection.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Preferences/Ethereum/Connection.tsx
@@ -28,7 +28,7 @@ export function PreferencesEthereumConnection() {
   }, [nav]);
 
   const menuItems = {
-    "Mainnet (Beta)": {
+    "Mainnet": {
       onClick: () => changeNetwork(EthereumConnectionUrl.MAINNET, "0x1"),
       detail:
         currentUrl === EthereumConnectionUrl.MAINNET ? <Checkmark /> : <></>,


### PR DESCRIPTION
Remove the (Beta) tag from Mainnet (Beta) in user settings/preferences for Ethereum RPC Connection.